### PR TITLE
Fix admin modal JS handling

### DIFF
--- a/resources/views/admin/admin.blade.php
+++ b/resources/views/admin/admin.blade.php
@@ -100,7 +100,7 @@ Contenido de administrador
 				</select>
 			</div>
 		
-		<hidden id = "idTmpUser" name="idTmpUser" value=""/>
+                <input type="hidden" id="idTmpUser" name="idTmpUser" value=""/>
         
       </div>
       <div class="modal-footer">
@@ -138,8 +138,8 @@ $(document).ready(function() {
 });
 
 function addPerfil(id, name){
-	$('#idTmpUser').value = id;
-	$('#usuarioSel').append(name);
+        $('#idTmpUser').val(id);
+        $('#usuarioSel').text(name);
 
 }
     </script>


### PR DESCRIPTION
## Summary
- fix hidden input field markup
- use `.val()` and `.text()` to populate the edit modal fields correctly

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685068a4842c8326b37e74ea1d6bccc2